### PR TITLE
Add dependency applications

### DIFF
--- a/src/detergent.app.src
+++ b/src/detergent.app.src
@@ -1,3 +1,4 @@
 {application, detergent,
  [{description, "An emulsifying Erlang SOAP library"},
-  {vsn, "0.2"}]}.
+  {vsn, "0.2"},
+  {applications, [kernel, stdlib, erlsom]}]}.


### PR DESCRIPTION
In order for relx to build application correctly, it needs to have dependency applications defined in the app.src